### PR TITLE
Update GitHub variable names in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ Make sure you have the following tools installed:
 ```bash
 # Bash
 export GITHUB_TOKEN=<your_github_token>
-export GIT_OWNER=<git_owner> # Use 'Azure' to use Microsoft official catalog
-export GIT_REPO=<git_repo> # Use 'deployment-environments' to use Microsoft official catalog
+export GITHUB_OWNER=<git_owner> # Use 'Azure' to use Microsoft official catalog
+export GITHUB_REPO=<git_repo> # Use 'deployment-environments' to use Microsoft official catalog
 ```
 
 PowerShell:
 ```PowerShell
 # PowerShell
 $env:GITHUB_TOKEN="<your_github_token>"
-$env:GIT_OWNER="<git_owner>" # Use 'Azure' to use Microsoft official catalog
-$env:GIT_REPO="<git_repo>" # Use 'deployment-environments' to use Microsoft official catalog
+$env:GITHUB_OWNER="<git_owner>" # Use 'Azure' to use Microsoft official catalog
+$env:GITHUB_REPO="<git_repo>" # Use 'deployment-environments' to use Microsoft official catalog
 ```
 
 2. Run `azd up` from the root folder of this repository and follow the prompts to bootstrap your DevCenter.


### PR DESCRIPTION
Fix a bug in the README.md file where instructions to create environment variables were provided with the wrong names, causing Terraform to fail.