### PR TITLE
Pre-provisioning checks (hooks)

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -3,5 +3,11 @@
 name: devcenter-ade-starter
 metadata:
   template: devcenter-ade-starter@0.0.1-beta
+hooks:
+  preprovision:
+    windows:
+      run: ./hooks/preprovision.ps1
+    posix:
+      run: ./hooks/preprovision.sh
 infra:
   provider: terraform

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -1,0 +1,23 @@
+<#
+.SYNOPSIS
+    This script is executed before the provisioning process starts to check if the
+    environment is ready for provisioning.
+#>
+
+# Check if environment variables are set
+if ($null -eq $env:GITHUB_OWNER) {
+    Write-Error "GITHUB_OWNER environment variable is not set."
+    exit 1
+}
+
+if ($null -eq $env:GITHUB_REPO) {
+    Write-Error "GITHUB_REPO environment variable is not set."
+    exit 1
+}
+
+if ($null -eq $env:GITHUB_TOKEN) {
+    Write-Error "GITHUB_TOKEN environment variable is not set."
+    exit 1
+}
+
+Write-Information "Environment variables are set."

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if environment variables are set
+if [ -z "$GITHUB_OWNER" ]; then
+    echo "GITHUB_OWNER environment variable is not set."
+    exit 1
+fi
+
+if [ -z "$GITHUB_REPO" ]; then
+    echo "GITHUB_REPO environment variable is not set."
+    exit 1
+fi
+
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN environment variable is not set."
+    exit 1
+fi
+
+echo "Environment variables are set."

--- a/infra/modules/devcenter_key_vault/main.tf
+++ b/infra/modules/devcenter_key_vault/main.tf
@@ -25,6 +25,15 @@ resource "azurerm_role_assignment" "rbac_assignments" {
 }
 
 ##############################
+# Wait for RBAC replication before creating secrets
+##############################
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [ azurerm_role_assignment.rbac_assignments ]
+
+  create_duration = "30s"
+}
+
+##############################
 # Secrets
 ##############################
 resource "azurerm_key_vault_secret" "secrets" {

--- a/infra/modules/devcenter_key_vault/main.tf
+++ b/infra/modules/devcenter_key_vault/main.tf
@@ -25,9 +25,9 @@ resource "azurerm_role_assignment" "rbac_assignments" {
 }
 
 ##############################
-# Wait for RBAC replication before creating secrets
+# Wait for RBAC propagation
 ##############################
-resource "time_sleep" "wait_30_seconds" {
+resource "time_sleep" "rbac_propagation" {
   depends_on = [ azurerm_role_assignment.rbac_assignments ]
 
   create_duration = "30s"
@@ -42,4 +42,6 @@ resource "azurerm_key_vault_secret" "secrets" {
   name         = each.key
   value        = each.value.value
   key_vault_id = azurerm_key_vault.key_vault.id
+
+  depends_on = [ time_sleep.rbac_propagation ]
 }


### PR DESCRIPTION
- Add pre-provisioning hook to ensure environment variables are set.
- Allow RBAC to propagate before creating AKV secrets.